### PR TITLE
New bdsl lib and assert_bdsl

### DIFF
--- a/prolog/bdsl_lib/nodeproj.bdsl.pl
+++ b/prolog/bdsl_lib/nodeproj.bdsl.pl
@@ -1,0 +1,21 @@
+%%
+%% BDsl definitions for node project
+%%
+:- use_module('../paragraph_bdsl').
+:- op(500, xfy, ':>').
+:- op(400, xfy, '-+').
+
+:- assert_bdsl([
+  
+  % root dev dir
+  pr('nodeproj') :> p([ '/c', 'Dev', 'Git', '$DevRoot' ]),
+
+  % build config
+  f('package.json') :> pr('nodeproj'), 
+  f('package.json') -+ s([name='node_dep', loc=jsonget('dependencies/:')], doc="node project dependency"),
+  s('node_dep') -+ i([name='node_dep_name', loc=key(), doc="node dependency name"]),
+  s('node_dep') -+ i([name='node_dep_ver', loc=val(), doc="node dependency version"])
+
+]).  
+
+% end of bdsl

--- a/prolog/paragraph_bdsl.pl
+++ b/prolog/paragraph_bdsl.pl
@@ -1,4 +1,4 @@
-:- module(paragraph_bdsl, [ ':>'/2, '-+'/2, p/1, d/2, z/2, f/1, s/1, i/1, contains/4 ]).
+:- module(paragraph_bdsl, [ ':>'/2, '-+'/2, p/1, d/2, z/2, f/1, s/1, i/1, assert_bdsl/1, contains/4 ]).
 
 :- op(500, xfy, ':>').
 :- op(400, xfy, '-+').
@@ -18,6 +18,12 @@
 :- discontiguous s/1.  % structured parameter specification
 :- dynamic i/1.
 :- discontiguous i/1.  % individual parameter specification 
+
+%% syntax helper
+assert_bdsl([]).
+assert_bdsl([H|T]) :-
+    assertz(H),
+    assert_bdsl(T).
 
 %% derived relationships
 contains(Container, s, InfoName, i) :-


### PR DESCRIPTION
- BDSL lib for paragraph_conf, with example assertions for a node project
- assert_bdsl mechanism to enable syntax-light BDSL declarations and their preprocessing 