### PR TITLE
Feature/new yaml syntax

### DIFF
--- a/prolog/paragraph.pl
+++ b/prolog/paragraph.pl
@@ -956,6 +956,7 @@ json_sub_prop_(Property, Obj0, Obj1) :-
 
 extract_property(Property, Obj0, Obj1) :-
     (atomic_list_concat(Props, ',', Property) -> extract_props(Obj0, Props, Obj1) ;
+        Property = ':' -> dict_pairs(Obj0, _, Pairs), extract_props(Pairs, Obj1) ;
         extract_prop(Obj0, Property, Obj1)
     ).
 

--- a/prolog/paragraph_conf.pl
+++ b/prolog/paragraph_conf.pl
@@ -55,7 +55,7 @@ assert_container_param(ContainerType, ContainerName, Param) :-
     py_call(Param:name, ParamName),
     py_call(Param:loc, ParamLoc),
     py_call(Param:doc, ParamDoc),
-    py_call(Param:params, SubParams, [py_object(true)]),
+    py_call(Param:params, SubParams, [py_object(false)]),
     % structured parameter ?
     (   SubParams \= [] ->
         assert_container_param_binding(ContainerType, ContainerName, s( [ name=ParamName, loc=ParamLoc, doc=ParamDoc ] ))


### PR DESCRIPTION
- jsonget with ":" returns all dict entries from the current json object
- fixed reading of pavement sub param list as native prolog list