### PR TITLE
Corrected navigate_graph_up based on new paramloc/6

### DIFF
--- a/prolog/paragraph.pl
+++ b/prolog/paragraph.pl
@@ -740,8 +740,8 @@ navigate_graph_up(Param,    App, [LocTerm,ContainerTerm|LocRest]) :-
     add_container_up(LocTerm),
     container_term(Container, ContainerTerm),
     navigate_graph_up(app(App), App, LocRest), !.
-navigate_graph_up(Param,    App, [LocTerm|LocRest]) :-
-    paramloc(App, Param, _Container, LocTerm, _ContLocTerm, _),
+navigate_graph_up(Param,    App, [LocTerm,applfile(Container)|LocRest]) :-
+    paramloc(App, Param, Container, LocTerm, _ContLocTerm, _),
     \+add_container_up(LocTerm),
     navigate_graph_up(app(App), App, LocRest), !.
 navigate_graph_up(Param,    App, [LocTerm|LocRest]) :-


### PR DESCRIPTION
Get the app container at the end of the list returned by navigate_graph_up.