### PR TITLE
pgraphlog: use of named graph, README section for SPARQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,9 +169,26 @@ Below is an example of YAML definition for the above mentioned pom_xml* paramete
 ## paragraph visualization
 
 A graph database system (RDFox, terminusdb, neo4j or equivalent) can be used to visualize parts of the graph. This is done by converting the BDsl facts of the prolog bdsl_lib to
-.ttl format, then importing the paragraph ontology and data info that system.
+.ttl format, then importing the paragraph ontology and data into that system.
 
 Example of visualization using RDFox:
 
 ![Paragraph graph visualization](doc/para_graph_visualization_rdfox.png)
 
+Sample SPARQL queries for RDFox:
+
+```sparql
+# Query resources of type Parameter in the named graph :para_graph
+SELECT ?x WHERE {
+  GRAPH :para_graph {
+    ?x rdf:type :Parameter .
+  }
+}
+
+# Query resource of type Container
+SELECT ?x WHERE {
+  GRAPH :para_graph {
+    ?x rdf:type :Container
+  }
+}
+```

--- a/pgraphlog/data/nodeproj_bdsl.ttl
+++ b/pgraphlog/data/nodeproj_bdsl.ttl
@@ -6,7 +6,9 @@
 
 # Faits dérivés de prolog/bdsl_lib/nodeproj.bdsl.pl
 
-node:nodeproj a :Container ;
+GRAPH :para_graph {
+
+node:nodeproj a :PathRef ;
     rdfs:label "nodeproj (bdsl pr 'nodeproj')" ;
     :hasPathList ("/opt" "paragraph" "ParagraphAng" "$DevRoot") .
 
@@ -30,3 +32,5 @@ node:node_dep_ver a :InfoParam ;
     rdfs:label "node_dep_ver" ;
     :loc "jsonget('val()')" ;
     :belongsTo node:node_dep .
+
+}

--- a/pgraphlog/owl2/paragraph_ontology.txt
+++ b/pgraphlog/owl2/paragraph_ontology.txt
@@ -4,6 +4,7 @@ Ontology( <https://github.com/Incodam/paragraph>
 
       SubClassOf( :InfoParam :Parameter )
       SubClassOf( :StructParam :Parameter )
+      SubClassOf( :PathRef :Container)
       SubClassOf( :ApplFile :Container )
       SubClassOf( :ArchiveFile :Container )
       SubClassOf( :WebPage :Container )

--- a/pgraphlog/rules/paragraph_rules.dlog
+++ b/pgraphlog/rules/paragraph_rules.dlog
@@ -1,0 +1,1 @@
+%% define paragraph rules here

--- a/prolog/paragraph_bdsl.pl
+++ b/prolog/paragraph_bdsl.pl
@@ -1,4 +1,4 @@
-:- module(paragraph_bdsl, [ ':>'/2, '-+'/2, p/1, d/2, z/2, f/1, s/1, i/1, assert_bdsl/1, assert_bdsl/2, retract_bdsl/1, retract_bdsl_all/0, contains/4 ]).
+:- module(paragraph_bdsl, [ ':>'/2, '-+'/2, p/1, pr/1,d/2, z/2, f/1, s/1, i/1, assert_bdsl/1, assert_bdsl/2, retract_bdsl/1, retract_bdsl_all/0, contains/4 ]).
 
 :- op(500, xfy, ':>').
 :- op(400, xfy, '-+').
@@ -8,6 +8,8 @@
 :- discontiguous '-+'/2.
 :- dynamic p/1.
 :- discontiguous p/1.  % path specification
+:- dynamic pr/1.
+:- discontiguous pr/1.  % path reference specification
 :- dynamic d/2.
 :- discontiguous d/2.  % directory specification
 :- dynamic z/2.


### PR DESCRIPTION
Corrected .ttl sample to work with named graph :para_graph
Added README section with example SPARQL queries 