### PR TITLE
moved file_match to new paragraph_commons, file matching use in BDsl

### DIFF
--- a/prolog/bdsl_lib/springboot.bdsl.pl
+++ b/prolog/bdsl_lib/springboot.bdsl.pl
@@ -19,8 +19,8 @@
   s('mvn_dep') -+ i([name='mvn_dep_ver', loc=xpath('//version(text)'), doc="maven dependency version"]),
 
   % archives
-  z('paragraph-ui-0.0.1-SNAPSHOT.war') :> pr('sbTarget'),
-  zr(sb_archive) :> z('paragraph-ui-0.0.1-SNAPSHOT.war'),
+  z('paragraph-ui-(version).war') :> pr('sbTarget'),
+  zr(sb_archive) :> z('paragraph-ui-(version).war'),
   zr(sb_archive) -+ f([name='pom.xml', loc=endswith('/pom.xml'), doc="maven project xml"])
 
 ]).  

--- a/prolog/paragraph.pl
+++ b/prolog/paragraph.pl
@@ -21,6 +21,7 @@
 :- use_module(library(regex)).
 :- use_module(library(www_browser)).
 :- use_module(library(yall)).
+:- use_module(paragraph_commons).
 :- use_module(paragraph_conf).
 :- use_module(js_dcg).
 :- use_module(java_dcg).
@@ -572,53 +573,6 @@ contloc_app_archive(_ArTest, _FileType, _AppId, _Version, file(_LocSpec), _Scope
 %    ).
 
 
-list([])     --> [].
-list([L|Ls]) --> [L], list(Ls).
-
-conc_of(Prefix, Suffix) --> list(Prefix), "version", list(Suffix).
-
-version_tok(VersionTokenStr, VePrefixStr, VeSuffixStr) :-
-    string_codes(VersionTokenStr, VersionTokenCodes),
-    phrase(conc_of(VePrefixL, VeSuffixL), VersionTokenCodes),
-    string_codes(VePrefixStr, VePrefixL),
-    string_codes(VeSuffixStr, VeSuffixL).
-
-% TODO: remove call to app_archive, use FileTest only
-archive_match(FileTest, FileList, File, FileType, Version, AppId) :-
-    (app_archive(FileType, AppId, ArNameTemplate, _), atom_codes(ArNameTemplate, Codes), memberchk(0'(, Codes),
-        split_string(ArNameTemplate, "()", "", [Prefix, VersionTokenStr, Suffix]),
-        version_tok(VersionTokenStr, VePrefix, VeSuffix),
-        (ground(Version), atom_length(Version, Len)  ->
-             (Len is 0 ->
-                  join_strings([Prefix, Suffix], "", FileStr)
-             ;
-                  join_strings([Prefix, VePrefix, Version, VeSuffix, Suffix], "", FileStr)
-             ),
-        %atom_string(FileTest, FileStr), File = FileTest
-             atom_string(File, FileStr)
-        ;
-             true
-        ),
-        member(File, FileList),
-        (\+ground(Version) ->
-             atom_concat(Prefix, Rest, File),
-             atom_concat(VersionToken, Suffix, Rest),
-             atom_length(VersionToken, VtLen),
-             (VtLen is 0 ->
-                  Version = ''
-             ;
-              atom_concat(VePrefix, VeRest, VersionToken),
-              atom_concat(Version, VeSuffix, VeRest)
-             )
-        ;
-             true
-        )
-    ;atom_concat('*.', FileType, FileTest), atom_concat('*', Suffix, FileTest),
-        member(File, FileList), atom_concat(_, Suffix, File)
-    ;
-        member(FileTest, FileList), File = FileTest, Version = ''
-    ).
-
 %% resolve_entry_spec(pv(Param), ActualEntry, Options) :-
 %%     paramval(Param, ActualEntry, Options),
 %%     format(atom(Message), 'Resolved entry spec pv(~w) to ~w', [Param, ActualEntry]),
@@ -658,40 +612,9 @@ contloc_app_file(_FileTest, _FileType, _AppId, _Version, file(_LocSpec), _Scoper
 %         Scoper1 = [af(file(LocSpec)) | Scoper0]
 %    ).
 
-% TODO: remove call to app_file, use FileTest only
-file_match(FileTest, FileList, File, FileType, Version, AppId) :-
-    (app_file(FileType, AppId, FileNameTemplate, _), atom_codes(FileNameTemplate, Codes), memberchk(0'(, Codes),
-        split_string(FileNameTemplate, "()", "", [Prefix, VersionTokenStr, Suffix]),
-        version_tok(VersionTokenStr, VePrefix, VeSuffix),
-        (ground(Version), atom_length(Version, Len)  ->
-             (Len is 0 ->
-                  join_strings([Prefix, Suffix], "", FileStr)
-             ;
-                  join_strings([Prefix, VePrefix, Version, VeSuffix, Suffix], "", FileStr)
-             ),
-             atom_string(File, FileStr)
-        ;
-             true
-        ),
-        member(File, FileList),
-        (\+ground(Version) ->
-             atom_concat(Prefix, Rest, File),
-             atom_concat(VersionToken, Suffix, Rest),
-             atom_length(VersionToken, VtLen),
-             (VtLen is 0 ->
-                  Version = ''
-             ;
-              atom_concat(VePrefix, VeRest, VersionToken),
-              atom_concat(Version, VeSuffix, VeRest)
-             )
-        ;
-             true
-        )
-    ;atom_concat('*.', FileType, FileTest), atom_concat('*', Suffix, FileTest),
-        member(File, FileList), atom_concat(_, Suffix, File)
-    ;
-        atomic_list_concat([FileTest, '.', FileType], FileName), member(FileName, FileList), File = FileName, Version = ''
-    ).
+% resolves the versioning of a file with -version suffix
+file_match(FileTest, FileList, File, FileType, Version) :-
+    paragraph_commons:file_match(FileTest, FileList, File, FileType, Version).
 
 %% parameters defined in paragraph_conf
 
@@ -734,13 +657,13 @@ paramv(Param, Val, Scoper0, Scoper1) :-
     foldl([A,B-S0,C-S1]>>transition(A,B,C,S0,S1), TdList, app(App)-Scoper0, Val-Scoper1).
 
 navigate_graph_up(app(App), App, []) :- !.
-navigate_graph_up(Param,    App, [LocTerm,ContainerTerm|LocRest]) :-
-    paramloc(App, Param, Container, LocTerm, _ContLocTerm, _),
+navigate_graph_up(Param,    App, [LocTerm,MatchedContainerTerm|LocRest]) :-
+    paramloc(App, Param, _Container, LocTerm, MatchedContainer, _ContLocTerm, _),
     add_container_up(LocTerm),
-    container_term(Container, ContainerTerm),
+    container_term(MatchedContainer, MatchedContainerTerm),
     navigate_graph_up(app(App), App, LocRest).
-navigate_graph_up(Param,    App, [LocTerm,applfile(Container)|LocRest]) :-
-    paramloc(App, Param, Container, LocTerm, _ContLocTerm, _),
+navigate_graph_up(Param,    App, [LocTerm,applfile(MatchedContainer)|LocRest]) :-
+    paramloc(App, Param, _Container, LocTerm, MatchedContainer, _ContLocTerm, _),
     \+add_container_up(LocTerm),
     navigate_graph_up(app(App), App, LocRest).
 navigate_graph_up(Param,    App, [LocTerm|LocRest]) :-
@@ -764,22 +687,22 @@ container_term(Container, zipfile(Container)) :-
 
 % xpath for a flat file
 transition(xpath(XpathAtom), file(FilePath), Val, Scoper0, Scoper1) :-
-    read_term_from_atom(XpathAtom, XpathTerm, []), % works if library(xpath) is in use
+    read_term_from_atom(XpathAtom, XpathTerm, [module(xpath)]),
     load_xml(FilePath, XmlRoot, _),
     xpath(XmlRoot, XpathTerm, Val),
     Scoper1 = Scoper0.
 
-% version using paramloc/6, if Scoper0 has no constraint
+% version using paramloc/7, if Scoper0 has no constraint
 transition(applfile(AppFile), app(AppId), file(FilePath), Scoper0, Scoper1) :-
-    paramloc(AppId, _Param, AppFile, _LocTerm, ResolvePathList, _ParamProps),
-    append(ResolvePathList, [AppFile], FilePathList),
+    paramloc(AppId, _Param, AppFile, _LocTerm, MatchedFile, ResolvePathList, _ParamProps),
+    append(ResolvePathList, [MatchedFile], FilePathList),
     atomic_list_concat(FilePathList, '/', FilePath),
     Scoper1 = [af(FilePath) | Scoper0].
 
-% version using paramloc/6, if Scoper0 has no constraint
+% version using paramloc/7, if Scoper0 has no constraint
 transition(warfile(AppFile), app(AppId), file(FilePath), Scoper0, Scoper1) :-
-    paramloc(AppId, _Param, AppFile, _LocTerm, ResolvePathList, _ParamProps),
-    append(ResolvePathList, [AppFile], FilePathList),
+    paramloc(AppId, _Param, AppFile, _LocTerm, MatchedFile, ResolvePathList, _ParamProps),
+    append(ResolvePathList, [MatchedFile], FilePathList),
     atomic_list_concat(FilePathList, '/', FilePath),
     Scoper1 = [ar(FilePath) | Scoper0].
 
@@ -800,7 +723,7 @@ paramval(Param, AppId, Version, Val, Scoper0, Scoper1) :-
 
 % xpath for an archive xml resource (war / jar / zip)
 transition(xpath(XpathAtom), stream(FileStream), Val, Scoper0, Scoper1) :-
-    read_term_from_atom(XpathAtom, XpathTerm, []), % works if library(xpath) is in use
+    read_term_from_atom(XpathAtom, XpathTerm, [module(xpath)]),
     load_xml(stream(FileStream), XmlRoot, _),
     xpath(XmlRoot, XpathTerm, Val),
     %close(FileStream),
@@ -875,7 +798,7 @@ paramval(Param, AppId, Version, Val, Scoper0, Scoper2) :-
 
 % nested xpath definitions
 transition(xpath(XpathAtom), ParentXml, Val, Scoper0, Scoper1) :-
-    read_term_from_atom(XpathAtom, XpathTerm, []), % works if library(xpath) is in use
+    read_term_from_atom(XpathAtom, XpathTerm, [module(xpath)]),
     xpath(ParentXml, XpathTerm, Val),
     Scoper1 = Scoper0.
 

--- a/prolog/paragraph_commons.pl
+++ b/prolog/paragraph_commons.pl
@@ -1,0 +1,58 @@
+/*
+ * paragraph commons
+ */
+:- module(paragraph_commons, [file_match/5, version_tok/3]).
+
+list([])     --> [].
+list([L|Ls]) --> [L], list(Ls).
+
+conc_of(Prefix, Suffix) --> list(Prefix), "version", list(Suffix).
+
+version_tok(VersionTokenStr, VePrefixStr, VeSuffixStr) :-
+    string_codes(VersionTokenStr, VersionTokenCodes),
+    phrase(conc_of(VePrefixL, VeSuffixL), VersionTokenCodes),
+    string_codes(VePrefixStr, VePrefixL),
+    string_codes(VeSuffixStr, VeSuffixL).
+
+file_match(FileTest, FileList, File, FileType, Version) :-
+    ( sub_atom(FileTest, _, 1, _, '(') ->
+        atomic_list_concat([Prefix, RestWithClosing], '(', FileTest),
+        atomic_list_concat([VersionToken, Suffix], ')', RestWithClosing),
+        version_tok(VersionToken, VePrefix, VeSuffix),
+        ( ground(Version) ->
+            ( Version == '' ->
+                atomic_list_concat([Prefix, Suffix], '', FileAtom)
+            ;
+                atomic_list_concat([Prefix, VePrefix, Version, VeSuffix, Suffix], '', FileAtom)
+            ),
+            File = FileAtom
+        ;
+            true
+        ),
+        member(File, FileList),
+        ( \+ ground(Version) ->
+            atom_concat(Prefix, Rest, File),
+            atom_concat(VersionTokenExtract, Suffix, Rest),
+            atom_length(VersionTokenExtract, VtLen),
+            ( VtLen =:= 0 ->
+                Version = ''
+            ;
+                atom_concat(VePrefix, VeRest, VersionTokenExtract),
+                atom_concat(Version, VeSuffix, VeRest)
+            )
+        ;
+            true
+        )
+    ;   member(FileTest, FileList),
+        File = FileTest,
+        Version = ''
+    ;   atom_concat('*.', FileType, FileTest), atom_concat('*', Suffix, FileTest),
+        member(File, FileList), 
+        atom_concat(_, Suffix, File)
+    ;
+        ground(FileType),
+        atomic_list_concat([FileTest, '.', FileType], FileName), 
+        member(FileName, FileList), 
+        File = FileName, 
+        Version = ''
+    ).

--- a/prolog/paragraph_conf.pl
+++ b/prolog/paragraph_conf.pl
@@ -1,8 +1,9 @@
-:- module(paragraph_conf, [ application_group/3, application/4, directory_alias/2, directory_alias/3, parameter/2, parameter/3, paramloc/5, paramloc/6, app_archive/4, app_file/4, search_option/3, transform_val/3 ]).
+:- module(paragraph_conf, [ application_group/3, application/4, directory_alias/2, directory_alias/3, parameter/2, parameter/3, paramloc/5, paramloc/7, app_archive/4, app_file/4, search_option/3, transform_val/3 ]).
 :- use_module(library(janus)).
 :- use_module(library(xpath)).
 :- use_module(library(yaml)).
 :- use_module(paragraph_bdsl).
+:- use_module(paragraph_commons).
 :- op(500, xfy, ':>').
 :- op(400, xfy, '-+').
 
@@ -139,14 +140,16 @@ parameter(Name, ParamShortName, SourcePvt) :-
     py_call(Param:name, ParamShortName),
     py_call(Param:pvt, SourcePvt).
 
-% application parameters - paramloc/6 
+% application parameters - paramloc/7 
 % connect the parameter's container to the application and resolve the path to the parameter
-paramloc(App, Param, AppFile, LocTerm, ResolvePathList, ParamProps) :-
+paramloc(App, Param, AppFile, LocTerm, MatchedFile, ResolvePathList, ParamProps) :-
     paramloc(Param, AppFile, LocTerm, PathList, ParamProps),
     resolve_path(PathList, ResolvePathList),
-    (match_app_by_container(App, AppFile, ResolvePathList) ; match_app_by_path(App, AppFile, ResolvePathList)).
+    (match_app_by_container(App, AppFile, MatchedFile, _MatchedVersion, ResolvePathList) 
+     ; 
+     match_app_by_path(App, AppFile, MatchedFile, _MatchedVersion, ResolvePathList)).
 
-match_app_by_container(App, Container, ResolvePathList) :-
+match_app_by_container(App, Container, MatchedContainer, MatchedVersion, ResolvePathList) :-
     (  app_archive(_, App, Container, _) 
      ;
        app_file(_, App, Container, _)
@@ -154,15 +157,17 @@ match_app_by_container(App, Container, ResolvePathList) :-
     atomic_list_concat(ResolvePathList, '/', ContainerDir),
     directory_files(ContainerDir, Entries),
     exclude(is_dot_file, Entries, CleanEntries),
-    member(Container, CleanEntries).
+    file_match(Container, CleanEntries, MatchedContainer, _ContainerType, MatchedVersion).
+    %member(Container, CleanEntries).
 
-match_app_by_path(App, AppFile, ResolvePathList) :-
+match_app_by_path(App, AppFile, MatchedFile, MatchedVersion, ResolvePathList) :-
     reverse(ResolvePathList, [AppShortName|_]),
     once(match_app_by_short_name(App, AppShortName)),
     atomic_list_concat(ResolvePathList, '/', AppFileDir),
     directory_files(AppFileDir, Entries),
     exclude(is_dot_file, Entries, CleanEntries),
-    member(AppFile, CleanEntries).
+    file_match(AppFile, CleanEntries, MatchedFile, _FileType, MatchedVersion).
+    %member(AppFile, CleanEntries).
 
 match_app_by_short_name(App, AppShortName) :-
     application(app, App, AppShortName, _).

--- a/t/commons_t.plt
+++ b/t/commons_t.plt
@@ -1,0 +1,56 @@
+:- use_module(library(plunit)).
+:- begin_tests(commons).
+:- use_module('../prolog/paragraph_commons').
+
+%% archive match
+
+% TODO - broken, should fail
+test('archive match, version is known') :-
+    FileList = [ '.', '..', 'paragraph-ui-0.1.war', 'paragraph-ui-0.2.war' ],
+    assertion(\+ paragraph_commons:file_match('paragraph-ui-0.9.war', FileList, 'paragraph-ui-0.1.war', war, '0.1')).
+
+test('archive match, version unknown') :-
+    FileList = [ '.', '..', 'paragraph-ui-0.1.war', 'paragraph-ui-0.2.war' ],
+    (paragraph_commons:file_match('paragraph-ui-(version).war', FileList, 'paragraph-ui-0.1.war', FileType, Ve1),
+     Ve1 = '0.1',
+     FileType = war
+    ),
+    (paragraph_commons:file_match('paragraph-ui-(version).war', FileList, 'paragraph-ui-0.2.war', FileType, Ve2),
+     Ve2 = '0.2',
+     FileType = war
+    ).
+
+test('archive match, with or without version') :-
+    FileList = [ '.', '..', 'paragraph-ui.war', 'paragraph-ui-0.2.war' ],
+    paragraph_commons:file_match('paragraph-ui(-version).war', FileList, 'paragraph-ui.war', war, ''),
+    paragraph_commons:file_match('paragraph-ui(-version).war', FileList, 'paragraph-ui-0.2.war', war, '0.2').
+
+test('archive match, without version') :-
+    FileList = [ '.', '..', 'paragraph-ui.war', 'paragraph-ui-0.2.war' ],
+    paragraph_commons:file_match('paragraph-ui.war', FileList, 'paragraph-ui.war', war, '').
+
+test('archive match, wilcard') :-
+    FileList = [ '.', '..', 'a.jar', 'b.jar' ],
+    paragraph_commons:file_match('*.jar', FileList, 'a.jar', jar, ''),
+    paragraph_commons:file_match('*.jar', FileList, 'b.jar', jar, '').
+
+%% file match
+
+test('file match, without version') :-
+    FileList = [ '.', '..', 'pom.xml', '' ],
+    paragraph_commons:file_match('pom.xml', FileList, 'pom.xml', pom, '').
+
+test('file match, wilcard') :-
+    FileList = [ '.', '..', 'a.xml', 'b.xml' ],
+    paragraph_commons:file_match('*.xml', FileList, 'a.xml', xml, ''),
+    paragraph_commons:file_match('*.xml', FileList, 'b.xml', xml, '').
+
+%% version tok
+
+test('version tok without wrappers') :-
+    paragraph_commons:version_tok(version, '', '').
+
+test('version tok with parentheses') :-
+    paragraph_commons:version_tok('(version)', '(', ')').
+
+:- end_tests(commons).

--- a/t/paramv_t.plt
+++ b/t/paramv_t.plt
@@ -2,56 +2,8 @@
 :- use_module(library(xpath)).
 :- begin_tests(paragraph_paramv).
 :- getenv('PARAGRAPH_HOME', Ph), format(atom(Ps), '~w/prolog', [ Ph ]), working_directory(_, Ps).
-:- use_module(paragraph).
+:- use_module('../prolog/paragraph').
 
-
-%% package version
-
-test('parse package type, version and app') :-
-    paragraph:package_version('paragraph-ui-0.1.war', war, '0.1', 'paragraph-ui').
-
-%% archive match
-
-% TODO - broken, should fail
-test('archive match, version is known') :-
-    FileList = [ '.', '..', 'paragraph-ui-0.1.war', 'paragraph-ui-0.2.war' ],
-    paragraph:archive_match('paragraph-ui-0.9.war', FileList, 'paragraph-ui-0.1.war', war, '0.1', 'paragraph-ui').
-
-test('archive match, version unknown') :-
-    FileList = [ '.', '..', 'paragraph-ui-0.1.war', 'paragraph-ui-0.2.war' ],
-    (paragraph:archive_match('paragraph-ui-(version).war', FileList, 'paragraph-ui-0.1.war', FileType, Ve1, 'paragraph-ui'),
-     Ve1 = '0.1',
-     FileType = war
-    ),
-    (paragraph:archive_match('paragraph-ui-(version).war', FileList, 'paragraph-ui-0.2.war', FileType, Ve2, 'paragraph-ui'),
-     Ve2 = '0.2',
-     FileType = war
-    ).
-
-test('archive match, with or without version') :-
-    FileList = [ '.', '..', 'paragraph-ui.war', 'paragraph-ui-0.2.war' ],
-    paragraph:archive_match('paragraph-ui(-version).war', FileList, 'paragraph-ui.war', war, '', 'paragraph-ui'),
-    paragraph:archive_match('paragraph-ui(-version).war', FileList, 'paragraph-ui-0.2.war', war, '0.2', 'paragraph-ui').
-
-test('archive match, without version') :-
-    FileList = [ '.', '..', 'paragraph-ui.war', 'paragraph-ui-0.2.war' ],
-    paragraph:archive_match('paragraph-ui.war', FileList, 'paragraph-ui.war', war, '', 'paragraph-ui').
-
-test('archive match, wilcard') :-
-    FileList = [ '.', '..', 'a.jar', 'b.jar' ],
-    paragraph:archive_match('*.jar', FileList, 'a.jar', jar, '', 'paragraph-verticles'),
-    paragraph:archive_match('*.jar', FileList, 'b.jar', jar, '', 'paragraph-verticles').
-
-%% file match
-
-test('file match, without version') :-
-    FileList = [ '.', '..', 'pom.xml', '' ],
-    paragraph:file_match('pom.xml', FileList, 'pom.xml', pom, '', 'paragraph-ui').
-
-test('file match, wilcard') :-
-    FileList = [ '.', '..', 'a.xml', 'b.xml' ],
-    paragraph:file_match('*.xml', FileList, 'a.xml', xml, '', 'paragraph-verticles'),
-    paragraph:file_match('*.xml', FileList, 'b.xml', xml, '', 'paragraph-verticles').
 
 %% contloc
 
@@ -94,7 +46,7 @@ test('navigate graph from json_ktext up') :-
     navigate_graph_up(json_ktext, 'paragraph-ui', L),
     L = [jsonget('d/_/t'), endswith(".json"), warfile('paragraph-ui(-version).war')].
 
-%% paramval
+%% paramv is the rewrite of paramval
 
 test('xpath -> xml file : find the pom version of paragraph project') :-
     paragraph:paramv(pom_xml_version, Val, [ag('paragraph'), ve(''), ad(paragraph_ui)], NewScoper),

--- a/t/paramval_t.plt
+++ b/t/paramval_t.plt
@@ -2,56 +2,14 @@
 :- use_module(library(xpath)).
 :- begin_tests(paragraph_paramval).
 :- getenv('PARAGRAPH_HOME', Ph), format(atom(Ps), '~w/prolog', [ Ph ]), working_directory(_, Ps).
-:- use_module(paragraph).
+:- use_module('../prolog/paragraph').
 
+%% Compatibility tests for old predicates written for paramval
 
 %% package version
 
 test('parse package type, version and app') :-
     paragraph:package_version('paragraph-ui-0.1.war', war, '0.1', 'paragraph-ui').
-
-%% archive match
-
-% TODO - broken, should fail
-test('archive match, version is known') :-
-    FileList = [ '.', '..', 'paragraph-ui-0.1.war', 'paragraph-ui-0.2.war' ],
-    paragraph:archive_match('paragraph-ui-0.9.war', FileList, 'paragraph-ui-0.1.war', war, '0.1', 'paragraph-ui').
-
-test('archive match, version unknown') :-
-    FileList = [ '.', '..', 'paragraph-ui-0.1.war', 'paragraph-ui-0.2.war' ],
-    (paragraph:archive_match('paragraph-ui-(version).war', FileList, 'paragraph-ui-0.1.war', FileType, Ve1, 'paragraph-ui'),
-     Ve1 = '0.1',
-     FileType = war
-    ),
-    (paragraph:archive_match('paragraph-ui-(version).war', FileList, 'paragraph-ui-0.2.war', FileType, Ve2, 'paragraph-ui'),
-     Ve2 = '0.2',
-     FileType = war
-    ).
-
-test('archive match, with or without version') :-
-    FileList = [ '.', '..', 'paragraph-ui.war', 'paragraph-ui-0.2.war' ],
-    paragraph:archive_match('paragraph-ui(-version).war', FileList, 'paragraph-ui.war', war, '', 'paragraph-ui'),
-    paragraph:archive_match('paragraph-ui(-version).war', FileList, 'paragraph-ui-0.2.war', war, '0.2', 'paragraph-ui').
-
-test('archive match, without version') :-
-    FileList = [ '.', '..', 'paragraph-ui.war', 'paragraph-ui-0.2.war' ],
-    paragraph:archive_match('paragraph-ui.war', FileList, 'paragraph-ui.war', war, '', 'paragraph-ui').
-
-test('archive match, wilcard') :-
-    FileList = [ '.', '..', 'a.jar', 'b.jar' ],
-    paragraph:archive_match('*.jar', FileList, 'a.jar', jar, '', 'paragraph-verticles'),
-    paragraph:archive_match('*.jar', FileList, 'b.jar', jar, '', 'paragraph-verticles').
-
-%% file match
-
-test('file match, without version') :-
-    FileList = [ '.', '..', 'pom.xml', '' ],
-    paragraph:file_match('pom.xml', FileList, 'pom.xml', pom, '', 'paragraph-ui').
-
-test('file match, wilcard') :-
-    FileList = [ '.', '..', 'a.xml', 'b.xml' ],
-    paragraph:file_match('*.xml', FileList, 'a.xml', xml, '', 'paragraph-verticles'),
-    paragraph:file_match('*.xml', FileList, 'b.xml', xml, '', 'paragraph-verticles').
 
 %% contloc
 


### PR DESCRIPTION
BDsl support for file matching syntax (paragraph_commons:file_match).